### PR TITLE
Fix some build issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "either"
@@ -684,6 +687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +839,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1134,12 +1149,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.29"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1147,16 +1164,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -30,7 +30,7 @@ enum Command {
 
 #[derive(Args, Debug, Clone)]
 #[command(next_help_heading = "Resource")]
-struct ResourceOptions {
+pub struct ResourceOptions {
     /// Entity from which telemetry data produced.
     /// key:value format expected (ex. service.name:foo)
     /// For a more detailed explanation, see https://opentelemetry.io/docs/instrumentation/js/resources/


### PR DESCRIPTION
Thanks for the great package! Though I found two issues that prevents me from using the package.

## Visibility problem

`nix shell '.'` complains that `ResourceOptions` has to be `pub` because it is used as a `pub` field of a `pub` structs `ExportMetricsContext` and `ExportLogsContext`. Fixed by making it `pub`.

<details>
<summary>Actual error log</summary>

```shellsession
$ nix shell '.'
[1/1/2 built] building opentelemetry-cli-0.1.0 (patchPhase): decompressing cargo artifacts from /nix/storeerror: builder for '/nix/store/9xs8ndlmwax51jskl6n9c075sfyjfw6n-opentelemetry-cli-0.1.0.drv' failed with exit code 101;
       last 25 log lines:
       >    Compiling opentelemetry-cli v0.1.0 (/build/source)
       > error[E0446]: private type `ResourceOptions` in public interface
       >   --> src/cli/export/log.rs:51:5
       >    |
       > 51 |     pub resources: ResourceOptions,
       >    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
       >    |
       >   ::: src/cli/mod.rs:33:1
       >    |
       > 33 | struct ResourceOptions {
       >    | ---------------------- `ResourceOptions` declared as private
       >
       > error[E0446]: private type `ResourceOptions` in public interface
       >   --> src/cli/export/metrics.rs:84:5
       >    |
       > 84 |     pub resources: ResourceOptions,
       >    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
       >    |
       >   ::: src/cli/mod.rs:33:1
       >    |
       > 33 | struct ResourceOptions {
       >    | ---------------------- `ResourceOptions` declared as private
       >
       > For more information about this error, try `rustc --explain E0446`.
       > error: could not compile `opentelemetry-cli` (lib) due to 2 previous errors
       For full logs, run 'nix-store -l /nix/store/9xs8ndlmwax51jskl6n9c075sfyjfw6n-opentelemetry-cli-0.1.0.drv'.
```
</details>

## `time` crate update

`cargo build` on the latest stable Rust toolchain `1.86.0` fails because the version of the `time` crate it uses is incompatible with Rust  `>=1.80.0`. Fixed by updating the dependency `cargo +1.70.0 update -p time`. I used an older version of `cargo`, because the latest version produces `Cargo.lock` of version 4, which older cargo unable to read.

<details>
<summary>Actual error log</summary>

```shellsession
$ cargo build
   Compiling time v0.3.29
error[E0282]: type annotations needed for `Box<_>`
  --> /home/misawa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/time-0.3.29/src/format_description/parse/mod.rs:83:9
   |
83 |     let items = format_items
   |         ^^^^^
...
86 |     Ok(items.into())
   |              ---- type must be known at this point
   |
   = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
```
</details>